### PR TITLE
Update guide for restoration

### DIFF
--- a/docs/developers/differences-from-ethereum.md
+++ b/docs/developers/differences-from-ethereum.md
@@ -16,7 +16,7 @@ On the mainnet, the Ethanos cycle lasts approximately 3 months, meaning that it 
 
 **If Your Account is Expired**:
 
-- Do not worry; it can be restored without any penalties.
+- Do not worry; it can be restored without any penalties. [How?](/developers/how-can-i-restore-my-account)
 - To restore your accounts, you can request to [restoration client](/operators/operate-restoration-client) for the restoration.
 - Currently, you need to operate your own restoration client, but future services will provide more convenient restoration options.
 

--- a/docs/developers/how-can-i-restore-my-account.md
+++ b/docs/developers/how-can-i-restore-my-account.md
@@ -19,7 +19,7 @@ A valid restore data should include the following fields.
 
 In order to construct your restore data, you should retrieve the proper `Fee` and `FeeRecipient` by sending a http request to the store server you will use. Typically the restore server will provide this through http request named something like `minimumFee` for fee information and `feeRecipient` for fee recipient. Your request will look something like this.
 ```
-curl -X GET "http://hostAddress:hostPort/mimimumFee"
+curl -X GET "http://hostAddress:hostPort/minimumFee"
 curl -X GET "http://hostAddress:hostPort/feeRecipient"
 ```
 

--- a/docs/developers/how-can-i-restore-my-account.md
+++ b/docs/developers/how-can-i-restore-my-account.md
@@ -25,7 +25,7 @@ curl -X GET "http://hostAddress:hostPort/feeRecipient"
 
 Now before sending this restore data, you have to sign it. There are multiple reasons for this procedure, but the most important reason is so the restore server can’t manipulate the restoration fee. You can sign the restore data by using the `SignRestoreData` function in the [types](https://pkg.go.dev/github.com/ethereum/go-ethereum/core/types) package. 
 
-After making a valid restore data and signing it, you can send the restore data through `reqeustRestoration` http post method. The request should look something like this.
+After making a valid restore data and signing it, you can send the restore data through `requestRestoration` http post method. The request should look something like this.
 
 ```
 curl -H 'Content-Type: application/json' \

--- a/docs/developers/how-can-i-restore-my-account.md
+++ b/docs/developers/how-can-i-restore-my-account.md
@@ -1,0 +1,47 @@
+---
+title: How can I restore my Account?
+description: Guide to restoring an expired account
+lang: en
+---
+
+To restore your account which was swept away to the nether layer, you need to send a restore data to the restore server. 
+
+### Restore Data
+
+A valid restore data should include the following fields.
+
+- ChainID - To prevent attacks across different networks
+- Target - Address of the target account to restore
+- SourceEpoch - The current `epochCoverage` of the target account. This field should be set to the default `epochCoverage` which is `current epoch -1` if the account is not currently existent.
+- TargetEpoch - Target epoch to restore the account.
+- Fee - Fee to pay the fee recipient.
+- FeeRecipient - Account the pay the restore fee, typically the owner account of the restore server
+
+In order to construct your restore data, you should retrieve the proper `Fee` and `FeeRecipient` by sending a http request to the store server you will use. Typically the restore server will provide this through http request named something like `minimumFee` for fee information and `feeRecipient` for fee recipient. Your request will look something like this.
+```
+curl -X GET "http://hostAddress:hostPort/mimimumFee"
+curl -X GET "http://hostAddress:hostPort/feeRecipient"
+```
+
+Now before sending this restore data, you have to sign it. There are multiple reasons for this procedure, but the most important reason is so the restore server can’t manipulate the restoration fee. You can sign the restore data by using the `SignRestoreData` function in the [types](https://pkg.go.dev/github.com/ethereum/go-ethereum/core/types) package. 
+
+After making a valid restore data and signing it, you can send the restore data through `reqeustRestoration` http post method. The request should look something like this.
+
+```
+curl -H 'Content-Type: application/json' \
+-X POST "http://localhost:32311/requestRestoration" \
+--data '{"chainId": "0x84442", 
+"target": "0x1923f626bb8dc025849e00f99c25fe2b2f7fb0db", 
+"sourceEpoch": "0x10",
+"targetEpoch": "0x5",
+"fee": "0x100",
+"feeRecipient": "0x07a565b7ed7d7a678680a4c162885bedbb695fe0",
+"v": "0x26",
+"r": "0x223a7c9bcf5531c99be5ea7082183816eb20cfe0bbc322e97cc5c7f71ab8b20e",
+"s": "0x2aadee6b34b45bb15bc42d9c09de4a6754e7000908da72d48cc7704971491663"
+}'
+```
+After the restore server validate the restore data and check if the fee is profitable, it will send the restore create the corresponding restoration proof and send a restoration transaction to restore your account.
+
+We are currently working on a more user friendly interface for signing and sending restore data. Until then, please use the solution above.
+

--- a/docs/operators/run-a-node.md
+++ b/docs/operators/run-a-node.md
@@ -202,11 +202,19 @@ If the combination is `geth --syncmode full --gcmode archive` then all blockchai
 
 **Choose the Number of Epochs to Store**:
 
-OverProtocol is lightweight because it only requires active and staged state data to progress blocks.
+By default the OverProtocol client runs with minimum storage usage. You can change the epochLimit flag to change how many checkpoints to store.
 
-You can use the **`geth --epochLimit 2`** command (default) to minimize storage by retaining only active and staged data.
+```sh
+$ geth --epochLimit X
+```
+This stores checkpoints states until X epoch to the past (default is set to minimum, which is 2).
 
-You can use the **`geth --epochLimit 0`** command (0 means unlimited) to store all inactive data in addition to active and staged data.
+```sh
+$ geth --epochLimit 0
+```
+This stores all inactive data in addition to active and staged data.
+
+Normally default setting is enough, but saving previous checkpoints can be usefull when you want to retrieve states from preivous epochs.
 
 ### Consensus Layer Sync Modes
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -151,6 +151,11 @@ const developersSidebar = [
   },
   {
     type: "doc",
+    label: "How to Restore an Expired Account",
+    id: "developers/how-can-i-restore-my-account",
+  },
+  {
+    type: "doc",
     label: "Client APIs",
     id: "developers/client-apis",
   },


### PR DESCRIPTION
Notion behind making a separate tab outside `Differences from Ethereum` : Someone might come solely because their account was expired and want to find how to restore accounts ASAP.